### PR TITLE
Add process_later! for async webhook processing

### DIFF
--- a/app/controllers/fuik/webhooks_controller.rb
+++ b/app/controllers/fuik/webhooks_controller.rb
@@ -17,7 +17,7 @@ module Fuik
         headers: headers
       )
 
-      process!(webhook_event)
+      process_later!(webhook_event)
 
       head :ok
     rescue Fuik::InvalidSignature
@@ -64,6 +64,13 @@ module Fuik
       return unless event_class
 
       event_class.new(webhook_event).process!
+    end
+
+    def process_later!(webhook_event)
+      event_class = event_class_for(webhook_event.provider, webhook_event.event_type)
+      return unless event_class
+
+      WebhookProcessingJob.perform_later(event_class.name, webhook_event)
     end
 
     def url_encoded_body?

--- a/app/jobs/fuik/webhook_processing_job.rb
+++ b/app/jobs/fuik/webhook_processing_job.rb
@@ -1,0 +1,7 @@
+module Fuik
+  class WebhookProcessingJob < ApplicationJob
+    def perform(event_class_name, webhook_event)
+      Object.const_get(event_class_name).new(webhook_event).process!
+    end
+  end
+end

--- a/test/jobs/fuik/webhook_processing_job_test.rb
+++ b/test/jobs/fuik/webhook_processing_job_test.rb
@@ -1,0 +1,19 @@
+require "test_helper"
+
+module Fuik
+  class WebhookProcessingJobTest < ActiveJob::TestCase
+    test "processes the webhook event" do
+      webhook_event = WebhookEvent.create!(
+        provider: "stripe",
+        event_id: "evt_job_123",
+        event_type: "checkout.session.completed",
+        body: {}.to_json,
+        headers: {}
+      )
+
+      WebhookProcessingJob.perform_now("Stripe::CheckoutSessionCompleted", webhook_event)
+
+      assert_equal "processed", webhook_event.reload.status
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,3 +7,5 @@ ActiveRecord::Migrator.migrations_paths = [ File.expand_path("../test/dummy/db/m
 ActiveRecord::Migrator.migrations_paths << File.expand_path("../db/migrate", __dir__)
 
 require "rails/test_help"
+
+ActiveJob::Base.queue_adapter = :inline


### PR DESCRIPTION
Replace synchronous process! in the webhooks controller with process_later!, which delegates to WebhookProcessingJob via ActiveJob. Falls back to :inline (synchronous) when no queue adapter is configured. Keeps process! available for explicit synchronous use.

Closes: https://github.com/Rails-Designer/fuik/issues/1