### PR TITLE
events#index json endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Visit `/webhooks` to see all received webhooks. Click any event to view all the 
 * **Copy payload as JSON**: click a button, payload is in your clipboard
 * **Download payload as JSON file**: keep it for testing, debugging or throw it at your LLM agent, bot or colleague
 * **Add `.json` to any URL**: get the raw payload without the UI
+* **`GET /events.json`**: index as JSON with filter support
 * **Click any key to get the Ruby accessor path**: click `product_id` (as seen in the screenshot above) and get `payload["line_items"][0]["product_id"]` (say what? 🤯)
 
 

--- a/app/controllers/fuik/events_controller.rb
+++ b/app/controllers/fuik/events_controller.rb
@@ -6,6 +6,11 @@ module Fuik
 
     def index
       @webhook_events = WebhookEvent.filtered(params).order(created_at: :desc)
+
+      respond_to do |format|
+        format.html
+        format.json { render json: @webhook_events }
+      end
     end
 
     def show

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,8 @@
 
 Fuik::Engine.routes.draw do
   root to: "events#index"
-  resources :events, only: %w[show] do
+
+  resources :events, only: %w[index show] do
     resources :retries, only: %w[create]
   end
   resources :downloads, only: %w[create]


### PR DESCRIPTION
Support for e.g. `http://localhost:3000/webhooks/events.json` and `http://localhost:3000/webhooks/events.json?provider=postmark`.