### PR TITLE
Do not use Rails 7.1 feature

### DIFF
--- a/fuik.gemspec
+++ b/fuik.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
 
   spec.summary = "A fish trap for webhooks"
   spec.description = "Fuik (Dutch for fish trap) is a Rails engine that catches and stores webhooks from any provider. View all events in the admin interface, then create event classes to add your business logic."
-  spec.homepage = "https://railsdesigner.com/fuik/"
+  spec.homepage = "https://railsdesigner.com/open-source/fuik/"
   spec.license = "MIT"
 
   spec.metadata["homepage_uri"] = spec.homepage

--- a/lib/fuik/engine.rb
+++ b/lib/fuik/engine.rb
@@ -8,7 +8,7 @@ module Fuik
 
     config.webhooks_controller_parent = "ActionController::Base"
     config.events_controller_parent = "ActionController::Base"
-    config.providers_allowed = Rails.env.local?
+    config.providers_allowed = Rails.env.development? || Rails.env.test?
 
     config.to_prepare do
       ActiveSupport.on_load(:action_view) do


### PR DESCRIPTION
`Rails.env.local?` was used while gemspec specified Rails 7.0.