### PR TITLE
Configure used ActiveJob

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,37 @@ end
 If `Provider::Base.verify!` exists, Fuik calls it automatically. Invalid signatures return 401 without storing the webhook.
 
 
+### Custom job class
+
+Webhook events are processed asynchronously by `Fuik::WebhookProcessingJob`. When processing raises, the event is marked as `failed` so you can retry it from the dashboard.
+
+Define a custom job class, then configure Fuik to use it:
+```ruby
+# app/jobs/webhook_processing_job.rb
+class WebhookProcessingJob < ApplicationJob
+  queue_as :webhooks
+
+  retry_on MyApp::WebhookError, attempts: 5
+  discard_on ActiveJob::DeserializationError
+
+  def perform(event_class_name, webhook_event)
+    event_class_name.safe_constantize.new(webhook_event).process!
+  end
+end
+```
+
+```ruby
+# config/initializers/fuik.rb
+Fuik.configure do |config|
+  config.webhook_processing_job_class = "WebhookProcessingJob"
+end
+```
+
+The `perform` method receives two arguments:
+- `event_class_name`: a string like `"Stripe::CheckoutSessionCompleted"` that resolves to your event class
+- `webhook_event`: the `Fuik::WebhookEvent` record with the payload, headers and status
+
+
 ### Provider allowlist
 
 By default:

--- a/app/jobs/fuik/webhook_processing_job.rb
+++ b/app/jobs/fuik/webhook_processing_job.rb
@@ -1,7 +1,15 @@
 module Fuik
   class WebhookProcessingJob < ApplicationJob
+    queue_as :default
+
+    discard_on ActiveJob::DeserializationError
+
     def perform(event_class_name, webhook_event)
       Object.const_get(event_class_name).new(webhook_event).process!
+    rescue => error
+      webhook_event.failed!(error)
+
+      raise
     end
   end
 end

--- a/app/models/fuik/webhook_event.rb
+++ b/app/models/fuik/webhook_event.rb
@@ -53,7 +53,7 @@ module Fuik
     def process_later!
       event_class = self.class.event_class_for(provider, event_type)
 
-      WebhookProcessingJob.perform_later(event_class.name, self) if event_class
+      Fuik.webhook_processing_job_class.constantize.perform_later(event_class.name, self) if event_class
     end
   end
 end

--- a/lib/fuik.rb
+++ b/lib/fuik.rb
@@ -1,7 +1,10 @@
+# frozen_string_literal: true
+
 require "fuik/version"
+require "fuik/errors"
+require "fuik/configuration"
 require "fuik/dot_access"
 require "fuik/engine"
 
 module Fuik
-  class InvalidSignature < StandardError; end
 end

--- a/lib/fuik/configuration.rb
+++ b/lib/fuik/configuration.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Fuik
+  mattr_accessor :webhook_processing_job_class, default: "Fuik::WebhookProcessingJob"
+
+  def self.configure
+    yield self
+  end
+end

--- a/lib/fuik/errors.rb
+++ b/lib/fuik/errors.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module Fuik
+  class InvalidSignature < StandardError; end
+end

--- a/test/jobs/fuik/webhook_processing_job_test.rb
+++ b/test/jobs/fuik/webhook_processing_job_test.rb
@@ -1,6 +1,12 @@
 require "test_helper"
 
 module Fuik
+  class FailingEvent < Event
+    def process!
+      raise "ProcessingError"
+    end
+  end
+
   class WebhookProcessingJobTest < ActiveJob::TestCase
     test "processes the webhook event" do
       webhook_event = WebhookEvent.create!(
@@ -14,6 +20,23 @@ module Fuik
       WebhookProcessingJob.perform_now("Stripe::CheckoutSessionCompleted", webhook_event)
 
       assert_equal "processed", webhook_event.reload.status
+    end
+
+    test "transitions event to failed state when processing raises" do
+      webhook_event = WebhookEvent.create!(
+        provider: "test",
+        event_id: "evt_fail_1",
+        event_type: "test",
+        body: {}.to_json,
+        headers: {}
+      )
+
+      assert_raises(RuntimeError) do
+        WebhookProcessingJob.perform_now("Fuik::FailingEvent", webhook_event)
+      end
+
+      assert_equal "failed", webhook_event.reload.status
+      assert_equal "ProcessingError", webhook_event.error
     end
   end
 end

--- a/test/lib/fuik/configuration_test.rb
+++ b/test/lib/fuik/configuration_test.rb
@@ -1,0 +1,17 @@
+require "test_helper"
+
+module Fuik
+  class ConfigurationTest < ActiveSupport::TestCase
+    test "provides default webhook_processing_job_class" do
+      assert_equal "Fuik::WebhookProcessingJob", Fuik.webhook_processing_job_class
+    end
+
+    test "configure sets webhook_processing_job_class" do
+      Fuik.configure { it.webhook_processing_job_class = "Custom::Job" }
+
+      assert_equal "Custom::Job", Fuik.webhook_processing_job_class
+    ensure
+      Fuik.webhook_processing_job_class = "Fuik::WebhookProcessingJob"
+    end
+  end
+end

--- a/test/models/fuik/webhook_event_test.rb
+++ b/test/models/fuik/webhook_event_test.rb
@@ -1,5 +1,21 @@
 require "test_helper"
 
+module Test
+  class Test < Fuik::Event
+    def process!
+      @webhook_event.processed!
+    end
+  end
+
+  class ProcessingJob < ActiveJob::Base
+    cattr_accessor :performed, default: false
+
+    def perform(*)
+      self.class.performed = true
+    end
+  end
+end
+
 module Fuik
   class WebhookEventTest < ActiveSupport::TestCase
     test "retry! resets and reprocesses a failed event" do
@@ -43,6 +59,26 @@ module Fuik
       )
 
       assert_raises(RuntimeError, match: /failed/) { event.retry! }
+    end
+
+    test "process_later! uses configured job class" do
+      original = Fuik.webhook_processing_job_class
+      event = WebhookEvent.create!(
+        provider: "test",
+        event_id: "evt_cfg_1",
+        event_type: "test",
+        body: {}.to_json,
+        headers: {}
+      )
+
+      Fuik.configure { it.webhook_processing_job_class = "Test::ProcessingJob" }
+
+      event.process_later!
+
+      assert Test::ProcessingJob.performed
+    ensure
+      Fuik.webhook_processing_job_class = original
+      Test::ProcessingJob.performed = false
     end
   end
 end


### PR DESCRIPTION
Last release add process later by default (via active job). 

This PR add some improvements + option to define your own job class.
```ruby
# app/jobs/webhook_processing_job.rb
class WebhookProcessingJob < ApplicationJob
  queue_as :webhooks

  retry_on WebhookError, attempts: 5
  discard_on ActiveJob::DeserializationError

  def perform(event_class_name, webhook_event)
    event_class_name.safe_constantize.new(webhook_event).process!
  end
end
```

```ruby
# config/initializers/fuik.rb
Fuik.configure do |config|
  config.webhook_processing_job_class = "WebhookProcessingJob"
end
```